### PR TITLE
No either t

### DIFF
--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -58,8 +58,10 @@ import           Servant.Server.Internal.SnapShims
 class HasServer layout where
   type ServerT layout (m :: * -> *) :: *
 
-  route :: MonadSnap m => Proxy layout -> m (RouteResult (Server layout m)) -> Router Request (RoutingApplication m) m
-  --route :: (MonadSnap m) => Proxy layout -> m (RouteResult (Server layout)) -> Router Request RoutingApplication
+  route :: MonadSnap m
+        => Proxy layout
+        -> m (RouteResult (Server layout m))
+        -> Router Request (RoutingApplication m) m
 
 type Server layout m = ServerT layout m
 

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -61,7 +61,7 @@ class HasServer layout where
   route :: MonadSnap m => Proxy layout -> m (RouteResult (Server layout m)) -> Router Request (RoutingApplication m) m
   --route :: (MonadSnap m) => Proxy layout -> m (RouteResult (Server layout)) -> Router Request RoutingApplication
 
-type Server layout m = ServerT layout (EitherT ServantErr m)
+type Server layout m = ServerT layout m
 
 -- * Instances
 
@@ -122,7 +122,7 @@ instance (KnownSymbol capture, FromText a, HasServer sublayout)
 
 methodRouter :: (AllCTRender ctypes a, MonadSnap m)
              => Method -> Proxy ctypes -> Status
-             -> m (RouteResult (EitherT ServantErr m a))
+             -> m (RouteResult (m a))
              -> Router Request (RoutingApplication m) m
 methodRouter method proxy status action = LeafRouter route'
   where
@@ -140,7 +140,7 @@ methodRouter method proxy status action = LeafRouter route'
 
 methodRouterHeaders :: (GetHeaders (Headers h v), AllCTRender ctypes v, MonadSnap m)
                     => Method -> Proxy ctypes -> Status
-                    -> m (RouteResult (EitherT ServantErr m (Headers h v)))
+                    -> m (RouteResult (m (Headers h v)))
                     -> Router Request (RoutingApplication m) m
 methodRouterHeaders method proxy status action = LeafRouter route'
   where
@@ -158,7 +158,7 @@ methodRouterHeaders method proxy status action = LeafRouter route'
       | otherwise = respond $ failWith NotFound
 
 methodRouterEmpty :: MonadSnap m => Method
-                  -> m (RouteResult (EitherT ServantErr m ()))
+                  -> m (RouteResult (m ()))
                   -> Router Request (RoutingApplication m) m
 methodRouterEmpty method action = LeafRouter route'
   where
@@ -645,17 +645,8 @@ instance (ToRawApplication m a, a ~ m ()) => HasServer (Raw m a) where
     r <- rawApplication
     case r of
       RR (Left err)      -> respond $ failWith err
-      RR (Right (rawApp)) -> (toRawApplication (unEitherT rawApp)) request (respond . succeedWith)
-      --RR (Right (Raw a)) -> (toRawApplication (Proxy :: Proxy m) app) request ( respond . succeedWith) -- XXX TODO
-        --runApp <- app request ((liftSnap <$> respond) . succeedWith)
-        --let b = runApp :: Int
+      RR (Right rawApp) -> (toRawApplication rawApp) request (respond . succeedWith)
 
-unEitherT :: MonadSnap m => EitherT ServantErr m a -> m () -- TODO FIX!
-unEitherT act = do
-  r <- runEitherT act
-  case r of
-    Left e  -> writeBS (B.pack (show e))
-    Right a -> return a >> return ()
 
 -- | If you use 'ReqBody' in one of the endpoints for your API,
 -- this automatically requires your server-side handler to be a function

--- a/src/Servant/Server/Internal/Router.hs
+++ b/src/Servant/Server/Internal/Router.hs
@@ -4,7 +4,6 @@ import           Data.Map                                   (Map)
 import qualified Data.Map                                   as M
 import           Data.Monoid                                ((<>))
 import           Data.Text                                  (Text)
---import           Network.Wai                 (Request, pathInfo)
 import           Servant.Server.Internal.PathInfo
 import           Servant.Server.Internal.RoutingApplication
 import           Snap.Core

--- a/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/src/Servant/Server/Internal/RoutingApplication.hs
@@ -102,7 +102,7 @@ responseLBS (Status code msg) hs body =
        return out)
     $ emptyResponse
 
-runAction :: MonadSnap m => m (RouteResult (EitherT ServantErr m a))
+runAction :: MonadSnap m => m (RouteResult (m a))
           -> (RouteResult Response -> m r)
           -> (a -> RouteResult Response)
           -> m r
@@ -111,10 +111,12 @@ runAction action respond k = do
   go r
   where
     go (RR (Right a))  = do
-      e <- runEitherT a
-      respond $ case e of
-        Right x  -> k x
-        Left err -> succeedWith $ responseServantErr err
+      e <- a
+      respond $ k e
+      -- e <- runEitherT a
+      -- respond $ case e of
+      --   Right x  -> k x
+      --   Left err -> succeedWith $ responseServantErr err
     go (RR (Left err)) = respond $ failWith err
 
 feedTo :: MonadSnap m => m (RouteResult (a -> b)) -> a -> m (RouteResult b)

--- a/src/Servant/Utils/StaticFiles.hs
+++ b/src/Servant/Utils/StaticFiles.hs
@@ -36,6 +36,4 @@ import qualified Snap.Util.FileServe               as Snap
 -- handler in the last position, because /servant/ will try to match the handlers
 -- in order.
 serveDirectory :: MonadSnap m => FilePath -> Server (Raw a (m ())) m
-serveDirectory fp = lift . liftSnap $ Snap.serveDirectory fp
-  -- (snapToApplication (Snap.serveDirectory fp) req handler)
-    --staticApp . defaultFileServerSettings . addTrailingPathSeparator
+serveDirectory fp = liftSnap $ Snap.serveDirectory fp

--- a/test/Servant/Server/Internal/EnterSpec.hs
+++ b/test/Servant/Server/Internal/EnterSpec.hs
@@ -5,65 +5,85 @@ module Servant.Server.Internal.EnterSpec where
 
 import qualified Control.Category              as C
 import           Control.Monad.Reader
-import           Control.Monad.Trans.Either
+import           Data.Aeson                    (decode')
+import qualified Data.ByteString.Char8         as B8
 import           Data.Proxy
 import           Servant.API
-import           Servant.Server
+import           Servant.Server                hiding (route)
 import           Servant.Server.Internal.SnapShims
 import           Snap.Core
 import           Snap.Snaplet
-import           Test.Hspec                    (Spec, describe, it, before)
---import           Test.Hspec.Wai                (get, matchStatus, post,
---                                                shouldRespondWith, with)
+import           Test.Hspec                    (Spec, describe, it)
+import           Test.Hspec.Core.Spec          (Result(Fail))
 import           Test.Hspec.Snap
 
--- data App = App
+type AppHandler = Handler App App
 
--- app :: SnapletInit App App
--- app = makeSnaplet "Enterapp" "A servant-snap test example app" Nothing $ do
---   return App
+data App = App
+
+app :: SnapletInit App App
+app = makeSnaplet "servantsnap" "A test app for servant-snap" Nothing $
+      return App
+
+app' :: HasServer api => Proxy api -> Server api AppHandler -> SnapletInit App App
+app' p s = makeSnaplet "servantsnap'" "A test app for servant-snap" Nothing $ do
+  addRoutes [("", applicationToSnap (serve p s))]
+  return App
+
+routes :: HasServer api
+       => Proxy api
+       -> Server api AppHandler
+       -> [(B8.ByteString, AppHandler ())]
+routes p s = [("", applicationToSnap (serve p s))]
+
 
 spec :: Spec
-spec = describe "module Servant.Server.Enter" $ do
-  return ()
---     enterSpec
+spec = describe "module Servant.Server.Enter"
+       enterSpec
 
--- type ReaderAPI = "int" :> Get '[JSON] Int
---             :<|> "string" :> Post '[JSON] String
+type ReaderAPI = "int"    :> Get '[JSON] Int
+            :<|> "string" :> Post '[JSON] String
 
--- type IdentityAPI = "bool" :> Get '[JSON] Bool
+type IdentityAPI = "bool" :> Get '[JSON] Bool
 
--- type CombinedAPI = ReaderAPI :<|> IdentityAPI
+type CombinedAPI = ReaderAPI :<|> IdentityAPI
 
--- readerAPI :: Proxy ReaderAPI
--- readerAPI = Proxy
+readerAPI :: Proxy ReaderAPI
+readerAPI = Proxy
 
--- combinedAPI :: Proxy CombinedAPI
--- combinedAPI = Proxy
+combinedAPI :: Proxy CombinedAPI
+combinedAPI = Proxy
 
--- readerServer' :: ServerT ReaderAPI (Reader String)
--- readerServer' = return 1797 :<|> ask
+readerServer' :: ServerT ReaderAPI (Reader String)
+readerServer' = return 1797 :<|> ask
 
--- fReader :: Reader String :~> EitherT ServantErr (Handler App App)
--- fReader = generalizeNat C.. (runReaderTNat "hi")
+fReader :: Reader String :~> AppHandler
+fReader = generalizeNat C.. runReaderTNat "hi"
 
--- readerServer :: Server ReaderAPI (Handler App App)
--- readerServer = enter fReader readerServer'
+readerServer :: Server ReaderAPI AppHandler
+readerServer = enter fReader readerServer'
 
--- combinedReaderServer' :: ServerT CombinedAPI (Reader String)
--- combinedReaderServer' = readerServer' :<|> enter generalizeNat (return True)
+combinedReaderServer' :: ServerT CombinedAPI (Reader String)
+combinedReaderServer' = readerServer' :<|> enter generalizeNat (return True)
 
--- combinedReaderServer :: Server CombinedAPI Snap
--- combinedReaderServer = enter fReader combinedReaderServer'
+combinedReaderServer :: Server CombinedAPI AppHandler
+combinedReaderServer = enter fReader combinedReaderServer'
 
--- enterSpec :: Spec
--- enterSpec = describe "Enter" $ do
---   beforeEval (return (serve readerAPI readerServer)) $ do
+shouldDecodeTo (Json _ bs) v = decode' bs `shouldEqual` Just v
+shouldDecodeTo _           _ = setResult (Fail Nothing "Should have been json body")
 
---     it "allows running arbitrary monads" $ do
---       get "int" `shouldEqual` Html "1797"
---       postJson "string" "3" `shouldEqual` Other 201
+enterSpec :: Spec
+enterSpec =
+  --snap (route (routes readerAPI readerServer)) app $
+  snap (route (routes combinedAPI combinedReaderServer)) (app' combinedAPI combinedReaderServer) $
+    describe "Enter" $ do
 
---   --before (return (serve combinedAPI combinedReaderServer)) $ do
---     it "allows combnation of enters" $ do
---       shouldBeTrue $ get "bool"
+      it "allows getting in arbitrary monads" $
+        get "int" >>= flip shouldDecodeTo (1797 :: Int)
+
+      it "allows posting in arbitrary monads" $
+        postJson "string" ("3" :: String) >>= shouldEqual (Other 201)
+
+      --before (return (serve combinedAPI combinedReaderServer)) $ do
+      it "allows combnation of enters" $
+        flip shouldDecodeTo True =<< get "bool"

--- a/test/Servant/ServerSpec.hs
+++ b/test/Servant/ServerSpec.hs
@@ -78,7 +78,6 @@ data App = App
 
 app :: SnapletInit App App
 app = makeSnaplet "servantsnap" "A test app for servant-snap" Nothing $ do
-  --wrapSite (\site -> applicationToSnap (serve captureApi captureServer) )
   return App
 
 routes :: HasServer api


### PR DESCRIPTION
Addresses #3, takes `Server` out of the EitherT ServantErr transformer. Since our handlers run in a MonadSnap m monad, it's natural to signal errors through snap. As a result servant-snap choice handlers can be `alternative`d together out of regular Snap handlers, rather than their lifted counterparts, and the server for a route that has some request parameters is just a function from the param type to a normal snap handler. No confusion about where to put an extra `return` or `lift`.

This might be going in a direction where a servant handler is more liberal than the one in the warp/wai based server, since we can move between snaplets, error out however we like, and even cheat by looking at data in the Request!

Another direction would be to deny access to the MonadSnap underneath, only allow IO, and force errors to go through ServantErr. Don't let the user invoke snaplets on their own accord, but force the use of particular snaplet features only through use of a combinator specific to that snaplet. I'm not sure how much safer this actually is, since even in warp/wai servant-server our handlers run in the IO monad and we can do arbitrary IO. Doing 'arbitrary snap' seems kind of analogous. And would this require all other parts of the servant ecosystem to deal with snap's special combinators?