### PR TITLE
Replace link to non-existent getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl localhost:8001/api/hello/DearUser
 
 ## Getting started
 
-We've written a [Getting Started](http://haskell-servant.github.io/getting-started/) guide that introduces the core types and features of servant. After this article, you should be able to write your first servant webservices, learning the rest from the haddocks' examples.
+We've written a [tutorial](http://haskell-servant.github.io/tutorial/) that introduces the core types and features of servant. After this article, you should be able to write your first servant webservices, learning the rest from the haddocks' examples.
 
 ## Repositories and Haddocks
 


### PR DESCRIPTION
Hi!
I wasn't sure if the 'getting started' guide changed to the 'tutorial' or if the getting started guide has moved locations. At any rate, I had a look around Servant's website and this tutorial is the closest I could find to a getting started guide. So I've updated the link.