### PR TITLE
Servant 0.15 0.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ matrix:
 before_install:
  - unset CC
  - mkdir -p ${HOME}/bin
- - mkdir -p deps
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/bin:$PATH
+ - mkdir deps
 
 install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/bin:$PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 Support servant 0.15 and 0.16, which have a new `Stream` combinator
 Drop support for servant < 0.15
-
+Correct the way imperativelly added headers in request/response are managed (fixing CORS issue)
+More CORS test coverage
 
 0.8.3
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.8.4
+-----
+
+Support servant 0.15 and 0.16, which have a new `Stream` combinator
+Drop support for servant < 0.15
+
+
 0.8.3
 -----
 

--- a/example/greet.hs
+++ b/example/greet.hs
@@ -15,7 +15,7 @@ import           Data.Text
 import           GHC.Generics
 import qualified Heist.Interpreted as I
 import           Snap.Core hiding (GET)
-import           Snap.CORS
+import           Snap.Util.CORS
 import           Snap.Snaplet
 import           Snap.Snaplet.Auth
 import           Snap.Snaplet.Session

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -4,8 +4,8 @@ let
   fixedNixpkgs = nixpkgs.fetchFromGitHub {
          owner = "NixOS";
          repo = "nixpkgs-channels";
-         rev = "bc94dcf500286495e3c478a9f9322debc94c4304";
-         sha256  = "1siqklf863181fqk19d0x5cd0xzxf1w0zh08lv0l0dmjc8xic64a";
+         rev = "4dd5c93998da55002fdec1c715c680531420381c";
+         sha256  = "06paxakic36nbdnwkkb1094fzp3lpzxxb1r57gmb3py6pb6xrcnh";
    };
 in
   import fixedNixpkgs { inherit overlays; }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -4,8 +4,8 @@ let
   fixedNixpkgs = nixpkgs.fetchFromGitHub {
          owner = "NixOS";
          repo = "nixpkgs-channels";
-         rev = "b96cd4134a8ae2fd8d37a60acc6e4921191e2818";
-         sha256  = "15vz6q0fy2xrpk1jwhdy2v7abg388sjqyjznr643gn2xg6k1nha2";
+         rev = "bc94dcf500286495e3c478a9f9322debc94c4304";
+         sha256  = "1siqklf863181fqk19d0x5cd0xzxf1w0zh08lv0l0dmjc8xic64a";
    };
 in
   import fixedNixpkgs { inherit overlays; }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -6,24 +6,38 @@ let
       servant-src = (pkgs.fetchFromGitHub {
                           owner  = "haskell-servant";
                           repo   = "servant";
-                          rev    = "b57528eff2c69feee2bb5dc43f37fa75b9daf417";
-                          sha256 = "1dgmqp9lw9zkb47r71568hlm86gvs0mmd8amc5sh7xcy220q7rbf";
-                        }) + "/servant";
+                          rev    = "b17c8bb8bd59ef8341bad07f9f7d0e230603612b";
+                          sha256 = "0dyn50gidzbgyq9yvqijnysai9hwd3srqvk8f8rykh09l375xb9j";
+                        });
+      hspec-snap-src = pkgs.fetchFromGitHub {
+                         owner  = "imalsogreg";
+                         repo   = "hspec-snap";
+                         rev    = "175cef28308627321c7b8792c198793dbb0e7914";
+                         sha256 = "0wr0bk5g0zs6hqrlrbvwndsrnjcwjmxyzkd17q73ln8gxzmvvrcs";
+                        };
     in {
       # haskellPackages = pkgs.haskell.packages.ghc822.override {
       haskellPackages = pkgs.haskellPackages.override {
         overrides = self: super: {
           #hspec-snap = dontCheck (self.callPackage ./pkgs/hspec-snap.nix {});
-          hspec-snap = doJailbreak super.hspec-snap;
+          hspec-snap = self.callCabal2nix "hspec-snap" hspec-snap-src {};
+          # hspec-snap = doJailbreak super.hspec-snap;
           lens        = dontCheck super.lens;
+          map-syntax  = dontCheck super.map-syntax;
           # servant     = dontCheck self."servant-0.12";
-          # servant     = dontCheck (self.callCabal2nix "servant" servant-src {});
-          servant       = self.servant_0_13;
-          servant-client       = self.servant-client_0_13;
-          servant-server       = self.servant-server_0_13;
+
+          # For servant-0.16. Comment it out to get servant-0.15:
+          # servant     = dontCheck (self.callCabal2nix "servant" (servant-src + "/servant") {});
+          # servant-client-core   = dontCheck (self.callCabal2nix "servant-client-core" (servant-src + "/servant-client-core") {});
+          # servant-client   = dontCheck (self.callCabal2nix "servant-client" (servant-src + "/servant-client") {});
+
+
+          # servant       = self.servant_0_13;
+          # servant-client       = self.servant-client_0_16;
+          # servant-server       = self.servant-server_0_16;
           heist       = dontCheck (super.heist);
-          text        = self.text_1_2_3_0;
-          http-types  = self.http-types_0_12_1;
+          # text        = self.text_1_2_3_0;
+          # http-types  = self.http-types_0_12_1;
         };
       };
     };

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -10,10 +10,10 @@ let
                           sha256 = "0dyn50gidzbgyq9yvqijnysai9hwd3srqvk8f8rykh09l375xb9j";
                         });
       hspec-snap-src = pkgs.fetchFromGitHub {
-                         owner  = "imalsogreg";
+                         owner  = "dbp";
                          repo   = "hspec-snap";
-                         rev    = "175cef28308627321c7b8792c198793dbb0e7914";
-                         sha256 = "0wr0bk5g0zs6hqrlrbvwndsrnjcwjmxyzkd17q73ln8gxzmvvrcs";
+                         rev    = "d13e3bd28b546728402e8e1ea2343b721c4b7dda";
+                         sha256 = "1x155cpb8fqkywvbanpankbly5410ly8v1nngpnmw8mnqldbfwd6";
                         };
     in {
       # haskellPackages = pkgs.haskell.packages.ghc822.override {
@@ -24,7 +24,6 @@ let
           # hspec-snap = doJailbreak super.hspec-snap;
           lens        = dontCheck super.lens;
           map-syntax  = dontCheck super.map-syntax;
-          # servant     = dontCheck self."servant-0.12";
 
           # For servant-0.16. Comment it out to get servant-0.15:
           # servant     = dontCheck (self.callCabal2nix "servant" (servant-src + "/servant") {});

--- a/servant-snap.cabal
+++ b/servant-snap.cabal
@@ -1,5 +1,5 @@
 name:                servant-snap
-version:             0.8.3
+version:             0.8.4
 synopsis:            A family of combinators for defining webservices APIs and serving them
 description:
   Interpret a Servant API as a Snap server, using any Snaplets you like.
@@ -21,7 +21,7 @@ copyright:           2014 Zalora South East Asia Pte Ltd
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.1
+tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5
 extra-source-files:
   CHANGELOG.md
   README.md
@@ -51,7 +51,6 @@ library
       , bytestring         >= 0.10 && < 0.11
       , case-insensitive   >= 1.2  && < 1.3
       , containers         >= 0.5  && < 0.7
-      , either             >= 4.3  && < 5.1
       , filepath           >= 1    && < 1.5
       , http-media         >= 0.7.1.2 && < 0.8
       , http-types         >= 0.8  && < 0.13
@@ -62,7 +61,7 @@ library
       , mmorph             >= 1    && < 1.2
       , servant            >= 0.15 && < 0.17
       , snap               >= 1.0  && < 1.2
-      , snap-core          >= 1.0.2  && < 1.2
+      , snap-core          >= 1.0  && < 1.1
       , snap-server        >= 1.0  && < 1.2
       , string-conversions >= 0.3  && < 0.5
       , tagged             >= 0.8.5 && < 0.9
@@ -82,7 +81,6 @@ executable snap-greet
       aeson
     , base
     , bytestring
-    , either
     , errors
     , heist
     , http-client
@@ -90,7 +88,6 @@ executable snap-greet
     , servant
     , servant-client
     , servant-snap
-    , snap-cors
     , map-syntax
     , snap
     , snap-core
@@ -105,6 +102,10 @@ test-suite spec
   default-language: Haskell2010
   hs-source-dirs: test
   main-is: Spec.hs
+  other-modules:
+    Servant.Utils.SnapTestUtils
+    Servant.ServerSpec
+    Servant.Server.CORSSpec
   build-depends:
       base               == 4.*
     , aeson
@@ -113,7 +114,6 @@ test-suite spec
     , case-insensitive
     , containers
     , directory
-    , either
     , exceptions
     , hspec              >= 2.4.3   && < 2.8
     , hspec-core         >= 2.4.3   && < 2.8
@@ -123,7 +123,6 @@ test-suite spec
     , process
     , digestive-functors >= 0.8.4.0 && < 0.9
     , time
-    , snap-cors
     , http-types
     , HUnit              >= 1.4
     , mtl

--- a/servant-snap.cabal
+++ b/servant-snap.cabal
@@ -60,13 +60,13 @@ library
       , network-uri        >= 2.6  && < 2.7
       , mtl                >= 2.0  && < 2.3
       , mmorph             >= 1    && < 1.2
-      , servant            >= 0.14 && < 0.15
-      , string-conversions >= 0.3  && < 0.5
-      , text               >= 1.2  && < 1.3
+      , servant            >= 0.15 && < 0.17
       , snap               >= 1.0  && < 1.2
       , snap-core          >= 1.0.2  && < 1.2
       , snap-server        >= 1.0  && < 1.2
+      , string-conversions >= 0.3  && < 0.5
       , tagged             >= 0.8.5 && < 0.9
+      , text               >= 1.2  && < 1.3
       , transformers       >= 0.3  && < 0.6
       , word8              >= 0.1  && < 0.2
   hs-source-dirs: src
@@ -116,13 +116,13 @@ test-suite spec
     , either
     , exceptions
     , hspec              >= 2.4.3   && < 2.8
+    , hspec-core         >= 2.4.3   && < 2.8
+    , hspec-snap         >= 1.0.1.0 && < 1.1
     , io-streams
     , lens
     , process
-    , digestive-functors >= 0.8.1.0 && < 0.9
+    , digestive-functors >= 0.8.4.0 && < 0.9
     , time
-    , hspec-snap         >= 1.0.1.0 && < 1.1
-    , hspec-core         >= 2.4.3   && < 2.8
     , snap-cors
     , http-types
     , HUnit              >= 1.4

--- a/src/Servant.hs
+++ b/src/Servant.hs
@@ -6,7 +6,7 @@ module Servant (
   -- | For implementing servers for servant APIs.
   module Servant.Server,
   -- | Utilities on top of the servant core
-  module Servant.Utils.Links,
+  module Servant.Links,
   module Servant.Utils.StaticFiles,
   -- | Useful re-exports
   Proxy(..),
@@ -15,5 +15,5 @@ module Servant (
 import Data.Proxy
 import Servant.API
 import Servant.Server
-import Servant.Utils.Links
+import Servant.Links
 import Servant.Utils.StaticFiles

--- a/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/src/Servant/Server/Internal/RoutingApplication.hs
@@ -49,7 +49,6 @@ data RouteResult a =
 toApplication :: forall m. MonadSnap m => RoutingApplication m -> Application m
 toApplication ra request respond = do
 
-  snapReq  <- getRequest
   r        <- ra request routingRespond
   snapResp <- getResponse
   rspnd <- respond (r `addHeaders` headers snapResp)

--- a/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/src/Servant/Server/Internal/RoutingApplication.hs
@@ -49,9 +49,9 @@ data RouteResult a =
 toApplication :: forall m. MonadSnap m => RoutingApplication m -> Application m
 toApplication ra request respond = do
 
-  r        <- ra request routingRespond
-  snapResp <- getResponse
-  rspnd <- respond (r `addHeaders` headers snapResp)
+  snapReq  <- getRequest
+  r        <- ra (request `addHeaders` headers snapReq) routingRespond
+  rspnd <- respond r
 
   -- liftIO $ putStrLn $ unlines [
   --   "----------"
@@ -70,7 +70,7 @@ toApplication ra request respond = do
   --   , "rspnd"
   --   , show rspnd
   --   ]
-  
+
   return rspnd
 
   -- snapReq  <- getRequest

--- a/src/Servant/Server/Internal/SnapShims.hs
+++ b/src/Servant/Server/Internal/SnapShims.hs
@@ -2,6 +2,7 @@
 
 module Servant.Server.Internal.SnapShims where
 
+import           Control.Monad.IO.Class
 import qualified Data.ByteString.Char8 as B
 import           Data.List             (foldl')
 import           Data.IORef
@@ -23,8 +24,9 @@ snapToApplication' snapAction req respond = do
 
 applicationToSnap :: MonadSnap m => Application m -> m ()
 applicationToSnap app = do
-  req <- getRequest
-  r <- app req return
+  req      <- getRequest
+  snapResp <- getResponse
+  r <- fmap (`addHeaders` headers snapResp) $ app req return
   putResponse r
 
 addHeaders :: HasHeaders a => a -> Headers -> a

--- a/test/Servant/Server/CORSSpec.hs
+++ b/test/Servant/Server/CORSSpec.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators     #-}
+
+module Servant.Server.CORSSpec where
+
+import           Control.Monad.IO.Class      (liftIO)
+import           Data.List                   (foldl')
+import           Data.Proxy
+import           Servant.API                 ((:<|>) (..), (:>), BasicAuth,
+                                              Capture, CaptureAll, Header (..),
+                                              Headers, IsSecure (..), JSON,
+                                              NoContent (..), NoFraming,
+                                              OctetStream, PlainText, QueryFlag,
+                                              QueryParam, QueryParams, Raw,
+                                              RemoteHost, ReqBody, SourceIO,
+                                              Stream, addHeader)
+import           Servant.API.Verbs           (Delete, Get, Patch, Post, Put,
+                                              Verb)
+import           Servant.Server              hiding (route)
+import           Servant.Server.Internal     (HasServer)
+import           Snap
+import qualified Snap.Core                   as SC
+import qualified Snap.Test                   as ST
+import qualified Snap.Util.CORS              as CORS
+import           Test.Hspec
+
+import           Servant.Utils.SnapTestUtils
+
+-- TODO: Cleanup
+spec :: Spec
+spec = do
+  corsSanitySpec
+
+corsSanitySpec :: Spec
+corsSanitySpec = do
+  let handler = CORS.applyCORS CORS.defaultOptions bareEndpoint
+      bareEndpoint = return ()
+
+      servantEndpoint :: Snap ()
+      servantEndpoint = do
+        let printHeaders m r = liftIO $ putStrLn m >> print (headers r)
+        respA <- SC.getResponse
+        serveSnap (Proxy :: Proxy ("int" :> Get '[JSON] Int)) (return  5 :: Snap Int)
+
+      servantSnapletInit :: SnapletInit () ()
+      servantSnapletInit = makeSnaplet "servant-test" "Testing servant" Nothing $ do
+        addRoutes [
+                   ("other", SC.writeText "other route")
+                  ,("", servantSnapletHandler)
+                  ]
+        wrapSite (CORS.applyCORS CORS.defaultOptions)
+        return ()
+
+      servantSnapletHandler :: Handler () () ()
+      servantSnapletHandler = do
+        let printHeaders m r = liftIO $ putStrLn m >> print (headers r)
+        respA <- SC.getResponse
+        serveSnap (Proxy :: Proxy ("int" :> Get '[JSON] Int)) (return  5 :: Handler () () Int)
+
+      forwardHeaders :: Snap ()
+      forwardHeaders = do
+          req  <- SC.getRequest
+          resp <- SC.getResponse
+          putResponse $ foldl' (\r (hk, hv) -> SC.setHeader hk hv r) resp (listHeaders req)
+
+      req :: ST.RequestBuilder IO ()
+      req = do
+        ST.setRequestType $ ST.RequestWithRawBody GET ""
+        ST.setRequestPath "/"
+        ST.setHeader "Origin" "http://origin.org"
+
+      req' :: ST.RequestBuilder IO ()
+      req' = do
+        ST.setRequestType $ ST.RequestWithRawBody GET ""
+        ST.setRequestPath "int"
+        ST.setHeader "Origin" "http://origin.org"
+
+      req'' :: ST.RequestBuilder IO ()
+      req'' = do
+        ST.setRequestType $ ST.RequestWithRawBody GET ""
+        ST.setRequestPath "other"
+        ST.setHeader "Origin" "http://origin.org"
+
+  it "Sets CORS and forwards req headers for Snap non-servant handler" $ do
+    resp <- ST.runHandler req (forwardHeaders >> handler)
+    Right resp `shouldHaveStatus` 200
+    Right resp `shouldHaveHeaders` [("Origin", "http://origin.org")
+                                   ,("Access-Control-Allow-Origin", "http://origin.org")]
+  it "Sets CORS and forwards req headers for Snap handler" $ do
+    resp <- ST.runHandler req' (CORS.applyCORS CORS.defaultOptions $ forwardHeaders >> servantEndpoint)
+    Right resp `shouldHaveStatus` 200
+    Right resp `shouldDecodeTo`   (5 :: Int)
+    Right resp `shouldHaveHeaders` [("Origin", "http://origin.org")
+                                   ,("Access-Control-Allow-Origin", "http://origin.org")
+                                   ]
+  it "Sets CORS and forwards req headers for Snaplet servant handler with wrapSite" $ do
+    resp <- testSnaplet servantSnapletInit req'
+    resp `shouldHaveStatus` 200
+    resp `shouldDecodeTo`   (5 :: Int)
+    resp `shouldHaveHeaders` [("Access-Control-Allow-Origin", "http://origin.org")
+                       ]
+
+  it "Sets CORS and forwards req headers for Snaplet not-servant handler with wrapSite" $ do
+    resp <- testSnaplet servantSnapletInit req''
+    resp `shouldHaveStatus` 200
+    resp `shouldHaveHeaders` [("Access-Control-Allow-Origin", "http://origin.org")
+                             ]

--- a/test/Servant/ServerSpec.hs
+++ b/test/Servant/ServerSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE OverloadedStrings    #-}
@@ -17,91 +17,76 @@ module Servant.ServerSpec where
 
 
 -------------------------------------------------------------------------------
-import           Control.Lens               (makeLenses)
-import           Control.Monad              (forM_, unless, void, when)
-import           Control.Monad.IO.Class     (liftIO)
-import           Data.Aeson                 (FromJSON, ToJSON)
-import qualified Data.Aeson                 as A
-import qualified Data.ByteString.Base64     as B64
-import qualified Data.ByteString.Char8      as B8
-import qualified Data.ByteString.Lazy       as BL
-import           Data.CaseInsensitive       (mk)
-import           Data.Char                  (toUpper)
-import           Data.Functor               ((<$>))
-import           Data.Maybe                 (fromMaybe)
+import           Control.Lens                                (makeLenses)
+import           Control.Monad                               (forM_, unless,
+                                                              void, when)
+import           Control.Monad.IO.Class                      (liftIO)
+import           Data.Aeson                                  (FromJSON, ToJSON)
+import qualified Data.Aeson                                  as A
+import qualified Data.ByteString.Base64                      as B64
+import qualified Data.ByteString.Char8                       as B8
+import qualified Data.ByteString.Lazy                        as BL
+import           Data.CaseInsensitive                        (mk)
+import           Data.Char                                   (toUpper)
+import           Data.Functor                                ((<$>))
+import           Data.List                                   (foldl')
+import           Data.Maybe                                  (fromMaybe)
 import           Data.Monoid
-import           Data.Proxy                 (Proxy (Proxy))
-import qualified Data.Set                   as Set
-import qualified Data.Text                  as T
-import qualified Data.Text.Lazy             as TL
-import qualified Data.Text.Encoding         as T
-import qualified Data.Text.Lazy.Encoding    as TL
-import           GHC.Generics               (Generic)
-import           Network.HTTP.Types         (hAccept, hContentType)
+import           Data.Proxy                                  (Proxy (Proxy))
+import qualified Data.Set                                    as Set
+import qualified Data.Text                                   as T
+import qualified Data.Text.Encoding                          as T
+import qualified Data.Text.Lazy                              as TL
+import qualified Data.Text.Lazy.Encoding                     as TL
+import           GHC.Generics                                (Generic)
+import           Network.HTTP.Types                          (hAccept,
+                                                              hContentType)
 import qualified Network.HTTP.Types
-import           Snap.Core                  hiding (Headers, addHeader)
-import qualified Snap.Core                  as SC
-import           Snap.CORS
+import           Snap.Core                                   hiding (Headers,
+                                                              addHeader)
+import qualified Snap.Core                                   as SC
 import           Snap.Snaplet
-import qualified Snap.Snaplet.Test          as SST
-import qualified Snap.Test                  as ST
+import qualified Snap.Snaplet.Test                           as SST
+import qualified Snap.Test                                   as ST
+import qualified Snap.Util.CORS                              as CORS
 -------------------------------------------------------------------------------
-import           Test.Hspec
-import           Test.Hspec.Snap            hiding (NotFound)
-import qualified Test.Hspec.Snap            as THS
-import qualified Test.HUnit                 as HU
-import           Servant.API                ((:<|>) (..), (:>),
-                                             addHeader, BasicAuth, Capture,
-                                             CaptureAll, Header (..), Headers,
-                                             IsSecure(..), JSON, NoContent(..),
-                                             NoFraming, OctetStream, PlainText, QueryFlag,
-                                             QueryParam, QueryParams, Raw,
-                                             RemoteHost, ReqBody, SourceIO, Stream)
-import           Servant.API.Verbs          (Verb, Get, Post, Put, Delete,
-                                             Patch)
-import qualified Servant.API.Verbs          as V
-import           Servant.Server              hiding (route)
-import           Servant.Server.Internal     (HasServer)
+import           Servant.API                                 ((:<|>) (..), (:>),
+                                                              BasicAuth,
+                                                              Capture,
+                                                              CaptureAll,
+                                                              Header (..),
+                                                              Headers,
+                                                              IsSecure (..),
+                                                              JSON,
+                                                              NoContent (..),
+                                                              NoFraming,
+                                                              OctetStream,
+                                                              PlainText,
+                                                              QueryFlag,
+                                                              QueryParam,
+                                                              QueryParams, Raw,
+                                                              RemoteHost,
+                                                              ReqBody, SourceIO,
+                                                              Stream, addHeader)
+import           Servant.API.Verbs                           (Delete, Get,
+                                                              Patch, Post, Put,
+                                                              Verb)
+import qualified Servant.API.Verbs                           as V
+import           Servant.Server                              hiding (route)
+import           Servant.Server.Internal                     (HasServer)
 import           Servant.Server.Internal.BasicAuth
 import           Servant.Server.Internal.Context
-import qualified Servant.Types.SourceT as S
+import qualified Servant.Types.SourceT                       as S
+import           Servant.Utils.SnapTestUtils
 import           Snap.Snaplet.Auth
 import           Snap.Snaplet.Auth.Backends.JsonFile
-import qualified Snap.Util.CORS as CORS
 import           Snap.Snaplet.Session
 import           Snap.Snaplet.Session.Backends.CookieSession
-
--------------------------------------------------------------------------------
--- * test data types
-
-data App = App { _auth :: Snaplet (AuthManager App)
-               , _sess :: Snaplet SessionManager}
-makeLenses 'App
-
-type AppHandler = Handler App App
-
-app :: SnapletInit App App
-app = app' []
-
-app' :: [(B8.ByteString, AppHandler ())] -> SnapletInit App App
-app' rs = makeSnaplet "servantsnap" "A test app for servant-snap" Nothing $ do
-  s <- nestSnaplet "sess" sess $
-           initCookieSessionManager "site_key.txt" "sess" Nothing (Just 3600)
-  a <- nestSnaplet "auth" auth $ initJsonFileAuthManager defAuthSettings sess "users.json"
-  addRoutes rs
-  wrapSite (\h -> createTestUserIfMissing >> CORS.applyCORS CORS.defaultOptions h)
-  return (App a s)
-
-createTestUserIfMissing :: Handler App App ()
-createTestUserIfMissing =
-  with auth $ usernameExists testLogin >>= \case
-    True  -> return ()
-    False -> void $ createUser testLogin testPassword
-
-testLogin    = "greg"
-testPassword = "p@ssword"
-
--------------------------------------------------------------------------------
+import qualified Snap.Util.CORS                              as CORS
+import           Test.Hspec
+import           Test.Hspec.Snap                             hiding (NotFound)
+import qualified Test.Hspec.Snap                             as THS
+import qualified Test.HUnit                                  as HU
 
 
 -- * Specs
@@ -124,6 +109,7 @@ spec = do
 ------------------------------------------------------------------------------
 -- * verbSpec {{{
 ------------------------------------------------------------------------------
+
 
 type VerbApi method status
     =                Verb method status '[JSON] Person
@@ -182,9 +168,10 @@ verbSpec = do
             liftIO $ statusIs response status `shouldBe` True
 
         let sInit = app' verbRoutes
-            runUrl p = SST.runHandler Nothing
-                       (mkRequest method p "" [] "")
-                       (serveSnap api server) sInit
+            runUrl p = testSnaplet sInit (mkRequest method p "" [] "")
+            -- runUrl p = SST.runHandler Nothing
+            --            (mkRequest method p "" [] "")
+            --            (serveSnap api server) sInit
 
         -- This group is run with hspec directly
 
@@ -207,14 +194,10 @@ verbSpec = do
           shouldHaveHeaders resp  [("H","5")]
 
         -- TODO: Why doesn't this test pass?
-        -- it "returs CORS headers" $ do
-        --   resp  <- SST.runHandler Nothing
-        --           (mkRequest method "/header" ""
-        --            [("Origin"
-        --             ,"http://example.com")] "")
-        --           (serveSnap api server) sInit
-        --   shouldHaveHeaders resp  [("access-control-allow-origin"
-        --                           ,"http://example.com")]
+        it "returs CORS headers" $ do
+          resp  <- testSnaplet sInit (mkRequest method "/noContent" "" [("Origin", "http://example.com")] "")
+          shouldHaveHeaders resp  [("access-control-allow-origin"
+                                  ,"http://example.com")]
 
         it "sets the content-type header" $ do
           resp <- SST.runHandler Nothing (mkRequest method "" "" [] "")
@@ -267,10 +250,10 @@ captureApi2 = Proxy
 captureServer2 :: Server CaptureApi2 '[] AppHandler
 captureServer2 _ = do
   rq <- getRequest
-  writeBS (SC.rqPathInfo rq) 
+  writeBS (SC.rqPathInfo rq)
 
 captureSpec :: Spec
-captureSpec = do -- snap (route (routes captureApi captureServer)) app $  
+captureSpec = do -- snap (route (routes captureApi captureServer)) app $
 
   let ( sInit , _ ) = mkInitAndServer captureApi  EmptyContext captureServer
       ( sInit2, _ ) = mkInitAndServer captureApi2 EmptyContext captureServer2
@@ -373,7 +356,7 @@ qpServer = queryParamServer :<|> qpNames :<|> qpCapitalize
         qpCapitalize True  = return alice { name = map toUpper (name alice) }
 
         queryParamServer (Just name_) = return alice{name = name_}
-        queryParamServer Nothing = return alice
+        queryParamServer Nothing      = return alice
 
 queryParamSpec :: Spec
 queryParamSpec = do
@@ -710,7 +693,7 @@ miscServ = versionHandler
 
   where versionHandler = return :: HttpVersion -> AppHandler HttpVersion
         secureHandler :: IsSecure -> AppHandler String
-        secureHandler Secure = return "secure"
+        secureHandler Secure    = return "secure"
         secureHandler NotSecure = return "not secure"
         hostHandler = return . B8.unpack  :: B8.ByteString -> AppHandler String
 
@@ -780,7 +763,7 @@ basicAuthSpec = do
       authHeader un pw = "Basic " <> B64.encode (T.encodeUtf8 un <> ":" <> pw)
 
   describe "Checks auth" $ do
-    
+
     it "returns 401 when not logged  in" $ do
       response <- runReqOnApi baApi (baCheck :. EmptyContext) getSecret SC.GET "/secret" "" [] ""
       response `shouldHaveStatus` 401
@@ -832,120 +815,22 @@ beholder = Animal "Beholder" 0
 ------------------------------------------------------------------------------
 
 getStatus :: TestResponse -> Maybe Int
-getStatus (Html (RespCode s) _) = Just s
-getStatus (Json (RespCode s) _) = Just s
-getStatus THS.NotFound = Nothing
+getStatus (Html (RespCode s) _)     = Just s
+getStatus (Json (RespCode s) _)     = Just s
+getStatus THS.NotFound              = Nothing
 getStatus (Redirect (RespCode s) _) = Just s
-getStatus (Other (RespCode s)) = Just s
-getStatus Empty = Nothing
+getStatus (Other (RespCode s))      = Just s
+getStatus Empty                     = Nothing
 
 statusIs :: TestResponse -> Int -> Bool
 statusIs r s = getStatus r == Just s
 
 decodesTo :: (FromJSON a, Eq a) => TestResponse -> a -> Bool
 decodesTo (Json _ bs) a = A.decode' bs == Just a
-decodesTo _ _ = False
+decodesTo _ _           = False
 
 bodyIs :: TestResponse -> TL.Text -> Bool
 bodyIs (Html _ t) target = t == TL.toStrict target
 bodyIs (Json _ b) target = b == TL.encodeUtf8 target
-bodyIs _ _ = False
+bodyIs _ _               = False
 
-------------------------------------------------------------------------------
--- * hspec helpers
-------------------------------------------------------------------------------
-
-shouldHaveBody :: Either T.Text Response -> T.Text -> IO ()
-shouldHaveBody (Left e) _ = HU.assertFailure $
-                            "Failed to respond: " ++ T.unpack e
-shouldHaveBody (Right r) a = do
-  bod <- ST.getResponseBody r
-  bod `shouldBe` T.encodeUtf8 a
-
-shouldHaveStatus :: Either T.Text Response -> Int -> IO ()
-shouldHaveStatus (Left e) _ = HU.assertFailure $
-                              "Failed to respond: " ++ T.unpack e
-shouldHaveStatus (Right r) a = do
-  SC.rspStatus r `shouldBe` a
-
-
-shouldDecodeTo :: (FromJSON a, Eq a, Show a)
-               => Either T.Text Response
-               -> a
-               -> IO ()
-shouldDecodeTo (Left e) _ = HU.assertFailure $
-                            "Failed to respond: " ++ T.unpack e
-shouldDecodeTo (Right resp) a = do
-  bod <- ST.getResponseBody resp
-  case A.decode' $ BL.fromStrict bod of
-    Just x | x == a -> return ()
-    Just _ -> HU.assertFailure $
-              "Failed to decode response to " ++ show a ++
-              " from body: " ++ B8.unpack bod
-    Nothing -> HU.assertFailure $ "Failed to decode respone from body: " ++
-               B8.unpack bod ++ "\nResponse: " ++ show resp
-    
-shouldHaveHeaders :: Either T.Text Response
-                  -> [(B8.ByteString, B8.ByteString)]
-                  -> Expectation
-shouldHaveHeaders (Left e) _ = expectationFailure $ T.unpack e
-shouldHaveHeaders (Right resp) hs = do
-  let respHs  = Set.fromList $ SC.listHeaders resp
-      hs'     = Set.fromList $  (\(k,v) -> (mk k,v)) <$> hs
-      missing = Set.toList $ Set.difference hs' respHs
-  case missing of
-    [] -> return ()
-    _  -> expectationFailure $
-     "These expected headers and values were missing: " ++ show missing ++
-     " from the response's: " ++ show (Set.toList respHs)
-
-
-------------------------------------------------------------------------------
--- * Assorted Snap helpers
-------------------------------------------------------------------------------
-
-mkInitAndServer :: (HasServer api context m, m ~ AppHandler)
-                => Proxy (api :: *)
-                -> Context context
-                -> Server api context AppHandler
-                -> (SnapletInit App App, AppHandler ())
-mkInitAndServer api ctx serv =
-  let sRoute = serveSnapWithContext api ctx serv
-  in  (app' [("", sRoute)], sRoute)
-
-
-mkRequest :: Method
-          -> B8.ByteString
-          -> B8.ByteString
-          -> [Network.HTTP.Types.Header]
-          -> B8.ByteString
-          -> ST.RequestBuilder IO ()
-mkRequest mth pth qs hds bdy = do
-  let ct = fromMaybe "" (Prelude.lookup hContentType hds)
-  ST.postRaw pth ct bdy
-  ST.setQueryStringRaw qs
-  unless (mth == SC.POST) $ ST.setRequestType (ST.RequestWithRawBody mth bdy)
-  forM_ hds (\(k, v) -> unless (k == hContentType) $ ST.addHeader k v)
-  -- req <- State.get -- Useful for debugging
-  -- liftIO $ print req
-
-runReqOnApi :: (HasServer api context m, m ~ AppHandler)
-            => Proxy (api :: *)
-            -> Context context
-            -> Server api context AppHandler
-            -> Method
-            -> B8.ByteString
-            -> B8.ByteString
-            -> [Network.HTTP.Types.Header]
-            -> B8.ByteString
-            -> IO (Either T.Text Response)
-runReqOnApi api ctx serv method route qs hds bod =
-  let (sInit, serv') = mkInitAndServer api ctx serv
-  in SST.runHandler Nothing (mkRequest method route qs hds bod) serv' sInit
-
-routes :: (HasServer api context m, m ~ AppHandler)
-       => Proxy (api :: *)
-       -> Context context
-       -> Server api context AppHandler
-       -> [(B8.ByteString, AppHandler ())]
-routes p ctx s = [("", serveSnapWithContext p ctx s)]

--- a/test/Servant/Utils/SnapTestUtils.hs
+++ b/test/Servant/Utils/SnapTestUtils.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Servant.Utils.SnapTestUtils where
+
+import           Control.Lens                                (makeLenses)
+import           Control.Monad                               (forM_, unless,
+                                                              void, when)
+import           Control.Monad.IO.Class                      (liftIO)
+import           Data.Aeson
+import qualified Data.Aeson                                  as A
+import qualified Data.ByteString.Char8                       as B8
+import qualified Data.ByteString.Lazy                        as BL
+import           Data.CaseInsensitive                        (mk)
+import           Data.List                                   (foldl')
+import           Data.Maybe                                  (fromMaybe)
+import           Data.Proxy
+import qualified Data.Set                                    as Set
+import qualified Data.Text                                   as T
+import qualified Data.Text.Encoding                          as T
+import           Network.HTTP.Types                          (hAccept,
+                                                              hContentType)
+import qualified Network.HTTP.Types
+import           Servant.API                                 ((:<|>) (..), (:>),
+                                                              BasicAuth,
+                                                              Capture,
+                                                              CaptureAll,
+                                                              Header (..),
+                                                              Headers,
+                                                              IsSecure (..),
+                                                              JSON,
+                                                              NoContent (..),
+                                                              NoFraming,
+                                                              OctetStream,
+                                                              PlainText,
+                                                              QueryFlag,
+                                                              QueryParam,
+                                                              QueryParams, Raw,
+                                                              RemoteHost,
+                                                              ReqBody, SourceIO,
+                                                              Stream, addHeader)
+import           Servant.API.Verbs                           (Delete, Get,
+                                                              Patch, Post, Put,
+                                                              Verb)
+import           Servant.Server                              hiding (route)
+import           Servant.Server.Internal                     (HasServer)
+import           Snap
+import qualified Snap.Core                                   as SC
+import           Snap.Snaplet
+import           Snap.Snaplet.Auth
+import           Snap.Snaplet.Auth.Backends.JsonFile
+import           Snap.Snaplet.Session
+import           Snap.Snaplet.Session.Backends.CookieSession
+import qualified Snap.Test                                   as ST
+import qualified Snap.Util.CORS                              as CORS
+import           Test.Hspec
+import qualified Test.HUnit                                  as HU
+
+
+data App = App { _auth :: Snaplet (AuthManager App)
+               , _sess :: Snaplet SessionManager}
+makeLenses 'App
+
+type AppHandler = Handler App App
+
+app :: SnapletInit App App
+app = app' []
+
+app' :: [(B8.ByteString, AppHandler ())] -> SnapletInit App App
+app' rs = makeSnaplet "servantsnap" "A test app for servant-snap" Nothing $ do
+  s <- nestSnaplet "sess" sess $
+           initCookieSessionManager "site_key.txt" "sess" Nothing (Just 3600)
+  a <- nestSnaplet "auth" auth $ initJsonFileAuthManager defAuthSettings sess "users.json"
+  addRoutes rs
+  wrapSite (\h -> createTestUserIfMissing >> CORS.applyCORS CORS.defaultOptions h)
+  return (App a s)
+
+createTestUserIfMissing :: Handler App App ()
+createTestUserIfMissing =
+  with auth $ usernameExists testLogin >>= \case
+    True  -> return ()
+    False -> void $ createUser testLogin testPassword
+
+testLogin    = "greg"
+testPassword = "p@ssword"
+------------------------------------------------------------------------------
+-- * Assorted Snap helpers
+------------------------------------------------------------------------------
+
+
+mkInitAndServer :: (HasServer api context m, m ~ AppHandler)
+                => Proxy (api :: *)
+                -> Context context
+                -> Server api context (AppHandler)
+                -> (SnapletInit App App, AppHandler ())
+mkInitAndServer api ctx serv =
+  let sRoute = serveSnapWithContext api ctx serv
+  in  (app' [("", sRoute)], sRoute)
+
+
+mkRequest :: Method
+          -> B8.ByteString
+          -> B8.ByteString
+          -> [Network.HTTP.Types.Header]
+          -> B8.ByteString
+          -> ST.RequestBuilder IO ()
+mkRequest mth pth qs hds bdy = do
+  let ct = fromMaybe "" (Prelude.lookup hContentType hds)
+  ST.postRaw pth ct bdy
+  ST.setQueryStringRaw qs
+  unless (mth == SC.POST) $ ST.setRequestType (ST.RequestWithRawBody mth bdy)
+  forM_ hds (\(k, v) -> unless (k == hContentType) $ ST.addHeader k v)
+  -- req <- State.get -- Useful for debugging
+  -- liftIO $ print req
+
+runReqOnApi :: (HasServer api context m, m ~ AppHandler)
+            => Proxy (api :: *)
+            -> Context context
+            -> Server api context AppHandler
+            -> Method
+            -> B8.ByteString
+            -> B8.ByteString
+            -> [Network.HTTP.Types.Header]
+            -> B8.ByteString
+            -> IO (Either T.Text Response)
+runReqOnApi api ctx serv method route qs hds bod =
+  let (sInit, serv') = mkInitAndServer api ctx serv
+  -- in SST.runHandler Nothing (mkRequest method route qs hds bod) serv' sInit
+  in testSnaplet sInit (mkRequest method route qs hds bod)
+
+routes :: (HasServer api context m, m ~ AppHandler)
+       => Proxy (api :: *)
+       -> Context context
+       -> Server api context (AppHandler)
+       -> [(B8.ByteString, AppHandler ())]
+routes p ctx s = [("", serveSnapWithContext p ctx s)]
+
+testSnaplet :: SnapletInit b b -> ST.RequestBuilder IO () -> IO (Either T.Text Response)
+testSnaplet snapletInit req = do
+  (_, snapm, _) <- runSnaplet Nothing snapletInit
+  fmap Right $ ST.runHandler req snapm
+
+------------------------------------------------------------------------------
+-- * hspec helpers
+------------------------------------------------------------------------------
+
+shouldHaveBody :: Either T.Text Response -> T.Text -> IO ()
+shouldHaveBody (Left e) _ = HU.assertFailure $
+                            "Failed to respond: " ++ T.unpack e
+shouldHaveBody (Right r) a = do
+  bod <- ST.getResponseBody r
+  bod `shouldBe` T.encodeUtf8 a
+
+shouldHaveStatus :: Either T.Text Response -> Int -> IO ()
+shouldHaveStatus (Left e) _ = HU.assertFailure $
+                              "Failed to respond: " ++ T.unpack e
+shouldHaveStatus (Right r) a = do
+  SC.rspStatus r `shouldBe` a
+
+
+shouldDecodeTo :: (FromJSON a, Eq a, Show a)
+               => Either T.Text Response
+               -> a
+               -> IO ()
+shouldDecodeTo (Left e) _ = HU.assertFailure $
+                            "Failed to respond: " ++ T.unpack e
+shouldDecodeTo (Right resp) a = do
+  bod <- ST.getResponseBody resp
+  case A.decode' $ BL.fromStrict bod of
+    Just x | x == a -> return ()
+    Just _ -> HU.assertFailure $
+              "Failed to decode response to " ++ show a ++
+              " from body: " ++ B8.unpack bod
+    Nothing -> HU.assertFailure $ "Failed to decode respone from body: " ++
+               B8.unpack bod ++ "\nResponse: " ++ show resp
+
+shouldHaveHeaders :: Either T.Text Response
+                  -> [(B8.ByteString, B8.ByteString)]
+                  -> Expectation
+shouldHaveHeaders (Left e) _ = expectationFailure $ T.unpack e
+shouldHaveHeaders (Right resp) hs = do
+  let respHs  = Set.fromList $ SC.listHeaders resp
+      hs'     = Set.fromList $  (\(k,v) -> (mk k,v)) <$> hs
+      missing = Set.toList $ Set.difference hs' respHs
+  case missing of
+    [] -> return ()
+    _  -> expectationFailure $
+     "These expected headers and values were missing: " ++ show missing ++
+     " from the response's: " ++ show (Set.toList respHs)
+


### PR DESCRIPTION
Support `servant-0.15` and `servant-0.16`, specifically using the new types introduced into the streaming API. This PR also fixes a longstanding issue around response headers set by imperative snap actions but discarded by servant-snap, for instance `CORS` headers added by `wrapSite (applyCORS defaultOptions)`. (see #17 and #24)